### PR TITLE
Improve/UI

### DIFF
--- a/src/components/notesSkeleton.tsx
+++ b/src/components/notesSkeleton.tsx
@@ -1,0 +1,15 @@
+import style from "./styles/notesskeleton.module.scss"
+
+const NotesSkeleton: React.FC = () =>{
+    return(
+        <div className={style.main}>
+            <div className={style.main__boxes}></div>
+            <div className={style.main__boxes}></div>
+            <div className={style.main__boxes}></div>
+            <div className={style.main__boxes}></div>
+            <div className={style.main__boxes}></div>
+        </div>
+    )
+}
+
+export default NotesSkeleton;

--- a/src/components/styles/notes.module.scss
+++ b/src/components/styles/notes.module.scss
@@ -1,6 +1,6 @@
 .main {
 	height: 200px;
-	width: 20%;
+	width: 19.3%;
 
 	display: flex;
 	justify-content: space-between;
@@ -10,11 +10,24 @@
 
 	padding: 1em;
 
+	border: 0.5px solid #f3eeee;
 	border-radius: 20px;
 
 	box-sizing: border-box;
 
 	text-align: left;
+
+	@media (max-width: 1244px) {
+		width: 19%;
+	}
+
+	@media (max-width: 900px) {
+		width: 24%;
+	}
+
+	@media (max-width: 850px) {
+		width: 32%;
+	}
 
 	@media (max-width: 768px) {
 		width: 100%;

--- a/src/components/styles/notesskeleton.module.scss
+++ b/src/components/styles/notesskeleton.module.scss
@@ -1,0 +1,55 @@
+.main {
+	width: 100%;
+	display: flex;
+	flex-wrap: wrap;
+	gap: 10px;
+
+	&__boxes {
+		height: 200px;
+		width: 19.3%;
+
+		display: flex;
+		justify-content: space-between;
+		flex-direction: column;
+
+		background-color: #fcfcfc;
+
+		padding: 1em;
+
+		border: 0.5px solid #f3eeee;
+		border-radius: 20px;
+
+		box-sizing: border-box;
+
+		text-align: left;
+
+		background: linear-gradient(90deg, #f0f0f0 25%, #e0e0e0 50%, #f0f0f0 75%);
+		background-size: 200% 100%;
+		animation: loading 1.5s infinite;
+
+		@media (max-width: 1244px) {
+			width: 19%;
+		}
+
+		@media (max-width: 900px) {
+			width: 24%;
+		}
+
+		@media (max-width: 850px) {
+			width: 32%;
+		}
+
+		@media (max-width: 768px) {
+			width: 100%;
+		}
+	}
+}
+
+@keyframes loading {
+	0% {
+		background-position: -200% 0;
+	}
+	100% {
+		background-position: 200% 0;
+	}
+}

--- a/src/pages/HomePage.tsx
+++ b/src/pages/HomePage.tsx
@@ -12,7 +12,7 @@ import NewNoteModal from "../components/newNoteModal";
 import { useAuth } from "../authContext/context";
 
 import { IoIosDocument } from "react-icons/io";
-import { BiLogOutCircle, BiPlusCircle } from "react-icons/bi";
+import { BiLogOutCircle, BiPlusCircle, BiPlus } from "react-icons/bi";
 
 import { noteDataModel } from "../ts/noteDataModel";
 
@@ -128,7 +128,7 @@ const HomePage: React.FC = () => {
 
           <div className={style.notes__new}>
             <button onClick={toggleModal} className={style.plus}>
-              <BiPlusCircle />
+              <BiPlus />
             </button>
           </div>
         </div>

--- a/src/pages/HomePage.tsx
+++ b/src/pages/HomePage.tsx
@@ -8,6 +8,7 @@ import style from "../styles/homepage.module.scss";
 
 import Notes from "../components/notes";
 import NewNoteModal from "../components/newNoteModal";
+import NotesSkeleton from "../components/notesSkeleton";
 
 import { useAuth } from "../authContext/context";
 
@@ -41,6 +42,18 @@ const HomePage: React.FC = () => {
     }
   };
 
+  //function to get a short version of title for better UI and prevent messy overflow
+  const shortifyTitle = (title: string | undefined) => {
+    const words = title?.split(" ");
+    const shortenedTitle = words?.slice(0, 5).join(" ");
+
+    if (words && words?.length <= 5) {
+      return title;
+    } else {
+      return shortenedTitle + "...";
+    }
+  };
+
   //function to format date notes from firebase timestamp
   const formatDate = (incomingDate: string | number | Date) => {
     return new Date(incomingDate).toLocaleDateString("en-GB", {
@@ -50,15 +63,19 @@ const HomePage: React.FC = () => {
     });
   };
 
+  //loading statement
+  const [loading, setLoading] = useState<boolean>(false);
   //notes array
   const [notes, setNotes] = useState<noteDataModel[] | null>([]);
   //get the User info from context
   const { user } = useAuth();
-  //fetch the notes with useCallback to prevent re-render infinite
+  //fetch the notes with useCallback to prevent infinite re-render
   const fetchNotes = useCallback(async (): Promise<void> => {
     try {
+      setLoading(true);
       const notes = await getNotes(user?.uid);
       setNotes(notes);
+      setLoading(false);
     } catch (error) {
       if (error instanceof Error) {
         console.log(error);
@@ -115,16 +132,20 @@ const HomePage: React.FC = () => {
             <h2>Notes</h2>
           </div>
 
-          <div className={style.notes__box}>
-            {notes?.map((note) => (
-              <Notes
-                key={note.id}
-                title={note.title}
-                bgColor={note.color}
-                lastEdit={formatDate(note.lastEdit)}
-              />
-            ))}
-          </div>
+          {loading ? (
+            <NotesSkeleton />
+          ) : (
+            <div className={style.notes__box}>
+              {notes?.map((note) => (
+                <Notes
+                  key={note.id}
+                  title={shortifyTitle(note.title)}
+                  bgColor={note.color}
+                  lastEdit={formatDate(note.lastEdit)}
+                />
+              ))}
+            </div>
+          )}
 
           <div className={style.notes__new}>
             <button onClick={toggleModal} className={style.plus}>

--- a/src/styles/homepage.module.scss
+++ b/src/styles/homepage.module.scss
@@ -12,8 +12,6 @@
 
 	line-height: 0;
 
-	transition: 0.3s;
-
 	&:hover {
 		background-color: #faad32;
 	}
@@ -133,8 +131,18 @@
 				.plus {
 					@include plusBtn(0, 4em);
 
+					background-color: #fff;
+
+					border-radius: 20px;
+
+					line-height: 0;
+
 					height: 70px;
 					width: 70px;
+
+					box-shadow: 1px 1px 5px 0px rgba(254, 200, 113, 1);
+					-webkit-box-shadow: 1px 1px 5px 0px rgba(254, 200, 113, 1);
+					-moz-box-shadow: 1px 1px 5px 0px rgba(254, 200, 113, 1);
 				}
 
 				@media (min-width: 768px) {


### PR DESCRIPTION
improve the UI
- redesign plus button for mobile and tablet view
- add border to notes box to prevent blank white space when note BG are white
- add function to get a short version of title to prevent long card and messy overflow
- add skeleton loading to prevent blank space when fetching data from firestore

from this =>
![Screenshot from 2023-09-07 15-23-40](https://github.com/Schleidens/cleep/assets/53914451/1a089f11-41d7-4ebe-a38b-b218ca1f8932)

to this =>
![Screenshot from 2023-09-07 14-57-14](https://github.com/Schleidens/cleep/assets/53914451/0418880c-c164-4854-bcbe-09e2f84f26c8)
![Screenshot from 2023-09-07 15-23-25](https://github.com/Schleidens/cleep/assets/53914451/4c9c69d0-6172-4de1-ae1d-276c9b67d383)

